### PR TITLE
feat: resolve nearest .editorconfig per file path with config caching

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,21 +38,22 @@ pnpm run dev           # Watch mode
 ### Testing
 
 - Run: `pnpm test` (vitest)
-- **Platform-gated tests**: Tests only run on macOS/Linux (see `platform() === 'darwin'` in tests)
 - **Test structure**: [tests/eslint-plugin.test.ts](../tests/eslint-plugin.test.ts) lints fixture files and verifies results
 - **Fixtures**: [tests/fixtures/eslint-plugin/](../tests/fixtures/eslint-plugin/) contains sample code to lint
 
 ### Code Quality
 
 ```bash
+pnpm run format        # Format code via oxfmt
+pnpm run format:check  # Check formatting without writing
 pnpm run lint          # ESLint with recommended config
 pnpm run typecheck     # TypeScript validation (tsgo --noEmit)
-pnpm run release:check # Full QA before release: lint + typecheck + test + build
+pnpm run release:check # Full QA: format:check → lint → typecheck → test → build
 ```
 
 ### Pre-commit & Release
 
-- Husky is configured for `prepare` hook
+- **Husky** + **nano-staged** for pre-commit: runs `eslint --fix` on supported files and `oxfmt` on all files
 - Release uses `bumpp` for version bumping
 - Must pass `release:check` before publishing
 
@@ -66,18 +67,15 @@ pnpm run release:check # Full QA before release: lint + typecheck + test + build
 
 ### Rule Options Format
 
-The rule accepts `FormatOptions` (from oxfmt) + `LoadOxfmtConfigOptions`:
-
-- `semi`, `singleQuote`, `tabWidth`, `useTabs`, `trailingComma`, `printWidth`, `arrowParens` (Prettier-like)
-- `jsxSingleQuote`, `bracketSameLine`, `singleAttributePerLine` (JSX-specific)
-- `bracketSpacing`, `quoteProps`, `endOfLine`, `insertFinalNewline` (object/line-ending)
-- `useConfig`, `cwd`, `configPath` (config loading behavior)
+The rule accepts `FormatConfig` (from oxfmt) merged with config-loading options (`useConfig`, `cwd`, `configPath`, `ignorePatterns`, `overrides`). See [README.md](../README.md#configuration-options) for the full options reference.
 
 ### Worker Thread Boundary
 
 - Worker is separate process—must serialize options properly
-- Import statements in [workers/oxfmt.mjs](../workers/oxfmt.mjs) are **CommonJS-compatible JSDoc-typed** (no TypeScript in worker)
+- [workers/oxfmt.mjs](../workers/oxfmt.mjs) is **plain JS with JSDoc types** (no TypeScript)—add `@param`/`@returns` type annotations to all functions
 - Worker receives: `(filename, sourceText, options?) → FormatResult`
+- Module-level caches (`resolvedBaseOptionsCache`, `mergedOptionsCache`, `picomatchCache`) use LRU eviction (`MAX_CACHE_SIZE`). Cache keys are serialized with `stableReplacer` for property-order-independent hashing
+- Config-level and rule-level `overrides` are merged (config first, rule-level appended). `ignorePatterns` uses `??` (nullish coalescing) so an explicit empty array from the rule takes precedence over config
 
 ### Parser Configuration
 
@@ -101,23 +99,23 @@ Uses `eslint-parser-plain` (re-exported in [src/parser.ts](../src/parser.ts)) to
 - **synckit** - Wraps worker calls in sync API for ESLint compatibility
 - **eslint-parser-plain** - Plain-text parser (no AST parsing)
 
-### Peer Dependency
+### Peer Dependencies
 
-- ESLint `^9.5.0` (flat config only—no legacy `eslintrc` support)
+- ESLint `^9.5.0 || ^10.0.0` (flat config only—no legacy `eslintrc` support)
+- oxfmt `>=0.42.0`
 
-### Monorepo Setup
+### Engine Requirements
 
-- Uses pnpm workspaces (see `pnpm-workspace.yaml`)
-- Root packages: Node.js 18+, pnpm 10.26.2+
+- Node.js `^20.19.0 || >=22.12.0`
+- pnpm `>=10.33.0`
 
 ## Debugging Tips
 
 ### Common Issues
 
-1. **Snapshot mismatches in tests** - Likely due to oxfmt version differences or platform variance. Update snapshots with `vitest -u`.
+1. **Snapshot mismatches in tests** - Update snapshots with `vitest -u`.
 2. **Worker thread errors** - Check [workers/oxfmt.mjs](../workers/oxfmt.mjs) JSDoc types match actual options passed from rule
 3. **Config not loading** - Verify `useConfig`, `cwd`, `configPath` options and that `.oxfmtrc` exists at correct path
-4. **Platform-specific test failures** - Tests skip on Windows; check test conditions in [tests/eslint-plugin.test.ts](../tests/eslint-plugin.test.ts)
 
 ### Local Testing
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,7 +74,7 @@ The rule accepts `FormatConfig` (from oxfmt) merged with config-loading options 
 - Worker is separate process—must serialize options properly
 - [workers/oxfmt.mjs](../workers/oxfmt.mjs) is **plain JS with JSDoc types** (no TypeScript)—add `@param`/`@returns` type annotations to all functions
 - Worker receives: `(filename, sourceText, options?) → FormatResult`
-- Module-level caches (`resolvedBaseOptionsCache`, `mergedOptionsCache`, `picomatchCache`) use LRU eviction (`MAX_CACHE_SIZE`). Cache keys are serialized with `stableReplacer` for property-order-independent hashing
+- Module-level caches (`resolvedBaseOptionsCache`, `mergedOptionsCache`, `picomatchCache`) use FIFO/oldest-entry eviction (`MAX_CACHE_SIZE`). Cache keys are serialized with `stableReplacer` for property-order-independent hashing
 - Config-level and rule-level `overrides` are merged (config first, rule-level appended). `ignorePatterns` uses `??` (nullish coalescing) so an explicit empty array from the rule takes precedence over config
 
 ### Parser Configuration

--- a/tests/__snapshots__/eslint-plugin.test.ts.snap
+++ b/tests/__snapshots__/eslint-plugin.test.ts.snap
@@ -182,72 +182,80 @@ exports[`should apply .editorconfig sections and keep oxfmt overrides higher pri
 exports[`should lint work > ts.ts 1`] = `
 [
   {
-    "column": 13,
-    "endColumn": 28,
-    "endLine": 4,
-    "fix": {
-      "text": "'hello world')",
-    },
-    "line": 4,
-    "message": "Replace \`"hello·world");\` with \`'hello·world')\`",
-    "messageId": "replace",
-    "ruleId": "oxfmt/oxfmt",
-    "severity": 2,
-  },
-  {
     "column": 1,
-    "endColumn": 5,
+    "endColumn": 31,
     "endLine": 7,
     "fix": {
-      "text": "",
+      "text": "console.log("hello world");",
     },
     "line": 7,
-    "message": "Delete \`····\`",
-    "messageId": "delete",
+    "message": "Replace \`····console.log('hello·world')\` with \`console.log("hello·world");\`",
+    "messageId": "replace",
     "ruleId": "oxfmt/oxfmt",
     "severity": 2,
   },
   {
-    "column": 22,
-    "endColumn": 23,
+    "column": 14,
+    "endColumn": 22,
     "endLine": 10,
     "fix": {
-      "text": "",
+      "text": ""foobar"",
     },
     "line": 10,
-    "message": "Delete \`;\`",
-    "messageId": "delete",
+    "message": "Replace \`'foobar'\` with \`"foobar"\`",
+    "messageId": "replace",
     "ruleId": "oxfmt/oxfmt",
     "severity": 2,
   },
   {
-    "column": 5,
-    "endColumn": 95,
+    "column": 21,
+    "endColumn": 65,
     "endLine": 13,
     "fix": {
-      "text": "
-  reallyLongArg(),
-  omgSoManyParameters(),
-  IShouldRefactorThis(),
-  isThereSeriouslyAnotherOne(),
-)",
+      "text": " omgSoManyParameters(), IShouldRefactorThis(), ",
     },
     "line": 13,
-    "message": "Replace \`reallyLongArg(),omgSoManyParameters(),IShouldRefactorThis(),isThereSeriouslyAnotherOne());\` with \`⏎··reallyLongArg(),⏎··omgSoManyParameters(),⏎··IShouldRefactorThis(),⏎··isThereSeriouslyAnotherOne(),⏎)\`",
+    "message": "Replace \`omgSoManyParameters(),IShouldRefactorThis(),\` with \`·omgSoManyParameters(),·IShouldRefactorThis(),·\`",
     "messageId": "replace",
     "ruleId": "oxfmt/oxfmt",
     "severity": 2,
   },
   {
-    "column": 15,
-    "endColumn": 18,
+    "column": 33,
+    "endColumn": 33,
     "endLine": 16,
     "fix": {
-      "text": "n",
+      "text": ";",
     },
     "line": 16,
-    "message": "Replace \`(n)\` with \`n\`",
+    "message": "Insert \`;\`",
+    "messageId": "insert",
+    "ruleId": "oxfmt/oxfmt",
+    "severity": 2,
+  },
+  {
+    "column": 9,
+    "endColumn": 17,
+    "endLine": 20,
+    "fix": {
+      "text": ""foobar"",
+    },
+    "line": 20,
+    "message": "Replace \`'foobar'\` with \`"foobar"\`",
     "messageId": "replace",
+    "ruleId": "oxfmt/oxfmt",
+    "severity": 2,
+  },
+  {
+    "column": 2,
+    "endColumn": 2,
+    "endLine": 22,
+    "fix": {
+      "text": ";",
+    },
+    "line": 22,
+    "message": "Insert \`;\`",
+    "messageId": "insert",
     "ruleId": "oxfmt/oxfmt",
     "severity": 2,
   },
@@ -256,11 +264,24 @@ exports[`should lint work > ts.ts 1`] = `
     "endColumn": 19,
     "endLine": 26,
     "fix": {
-      "text": "name: 'foobar',",
+      "text": "name: "foobar",",
     },
     "line": 26,
-    "message": "Replace \`'name':·'foobar'\` with \`name:·'foobar',\`",
+    "message": "Replace \`'name':·'foobar'\` with \`name:·"foobar",\`",
     "messageId": "replace",
+    "ruleId": "oxfmt/oxfmt",
+    "severity": 2,
+  },
+  {
+    "column": 2,
+    "endColumn": 2,
+    "endLine": 27,
+    "fix": {
+      "text": ";",
+    },
+    "line": 27,
+    "message": "Insert \`;\`",
+    "messageId": "insert",
     "ruleId": "oxfmt/oxfmt",
     "severity": 2,
   },
@@ -463,6 +484,60 @@ format(
     },
   ],
 }
+`;
+
+exports[`should match config-derived overrides relative to config directory, not ESLint cwd > packages/a/src/example.ts 1`] = `
+[
+  {
+    "column": 27,
+    "endColumn": 39,
+    "endLine": 1,
+    "fix": {
+      "text": "
+  name: string,
+",
+    },
+    "line": 1,
+    "message": "Replace \`name:·string\` with \`⏎··name:·string,⏎\`",
+    "messageId": "replace",
+    "ruleId": "oxfmt/oxfmt",
+    "severity": 2,
+  },
+  {
+    "column": 1,
+    "endColumn": 62,
+    "endLine": 2,
+    "fix": {
+      "text": "  return createUserProfile(
+    name,
+    'a very long display name',
+  ",
+    },
+    "line": 2,
+    "message": "Replace \`····return·createUserProfile(name,·"a·very·long·display·name"\` with \`··return·createUserProfile(⏎····name,⏎····'a·very·long·display·name',⏎··\`",
+    "messageId": "replace",
+    "ruleId": "oxfmt/oxfmt",
+    "severity": 2,
+  },
+]
+`;
+
+exports[`should match config-derived overrides relative to config directory, not ESLint cwd > packages/a/src/normal.js 1`] = `
+[
+  {
+    "column": 3,
+    "endColumn": 30,
+    "endLine": 2,
+    "fix": {
+      "text": "console.log('hello world'",
+    },
+    "line": 2,
+    "message": "Replace \`··console.log("hello·world"\` with \`console.log('hello·world'\`",
+    "messageId": "replace",
+    "ruleId": "oxfmt/oxfmt",
+    "severity": 2,
+  },
+]
 `;
 
 exports[`should merge .editorconfig with .oxfmtrc.json 1`] = `

--- a/tests/__snapshots__/eslint-plugin.test.ts.snap
+++ b/tests/__snapshots__/eslint-plugin.test.ts.snap
@@ -662,6 +662,111 @@ exports[`should prioritize rule ignorePatterns over .oxfmtrc ignorePatterns > ig
 
 exports[`should prioritize rule ignorePatterns over .oxfmtrc ignorePatterns > src/unformatted.js 1`] = `[]`;
 
+exports[`should resolve nearest .editorconfig per file path 1`] = `
+{
+  "fixture": "nearest-editorconfig",
+  "summary": [
+    {
+      "file": "src/nested/child.js",
+      "messages": [
+        {
+          "column": 33,
+          "endColumn": 37,
+          "endLine": 1,
+          "fix": {
+            "text": "
+      name,
+",
+          },
+          "line": 1,
+          "message": "Replace \`name\` with \`⏎······name,⏎\`",
+          "messageId": "replace",
+          "ruleId": "oxfmt/oxfmt",
+          "severity": 2,
+        },
+        {
+          "column": 1,
+          "endColumn": 62,
+          "endLine": 2,
+          "fix": {
+            "text": "      return createUserProfile(
+            name,
+            'a very long display name',
+      ",
+          },
+          "line": 2,
+          "message": "Replace \`····return·createUserProfile(name,·"a·very·long·display·name"\` with \`······return·createUserProfile(⏎············name,⏎············'a·very·long·display·name',⏎······\`",
+          "messageId": "replace",
+          "ruleId": "oxfmt/oxfmt",
+          "severity": 2,
+        },
+        {
+          "column": 2,
+          "endColumn": 1,
+          "endLine": 4,
+          "fix": {
+            "text": "",
+          },
+          "line": 3,
+          "message": "Delete \`⏎\`",
+          "messageId": "delete",
+          "ruleId": "oxfmt/oxfmt",
+          "severity": 2,
+        },
+      ],
+      "output": "export function buildNestedUser(
+      name,
+) {
+      return createUserProfile(
+            name,
+            'a very long display name',
+      );
+}",
+    },
+    {
+      "file": "src/root.js",
+      "messages": [
+        {
+          "column": 3,
+          "endColumn": 62,
+          "endLine": 2,
+          "fix": {
+            "text": "return createUserProfile(
+    name,
+    'a very long display name',
+  ",
+          },
+          "line": 2,
+          "message": "Replace \`··return·createUserProfile(name,·"a·very·long·display·name"\` with \`return·createUserProfile(⏎····name,⏎····'a·very·long·display·name',⏎··\`",
+          "messageId": "replace",
+          "ruleId": "oxfmt/oxfmt",
+          "severity": 2,
+        },
+        {
+          "column": 2,
+          "endColumn": 1,
+          "endLine": 4,
+          "fix": {
+            "text": "",
+          },
+          "line": 3,
+          "message": "Delete \`⏎\`",
+          "messageId": "delete",
+          "ruleId": "oxfmt/oxfmt",
+          "severity": 2,
+        },
+      ],
+      "output": "export function buildRootUser(name) {
+  return createUserProfile(
+    name,
+    'a very long display name',
+  );
+}",
+    },
+  ],
+}
+`;
+
 exports[`should respect ignorePatterns from .oxfmtrc when useConfig is true > ignored/unformatted.js 1`] = `[]`;
 
 exports[`should respect ignorePatterns from .oxfmtrc when useConfig is true > src/unformatted.js 1`] = `

--- a/tests/eslint-plugin.test.ts
+++ b/tests/eslint-plugin.test.ts
@@ -132,10 +132,14 @@ it('should lint work', async () => {
     ignore: false,
     overrideConfigFile: true,
     overrideConfig: [
-      // recommended config
+      // recommended config with useConfig disabled to avoid
+      // inheriting root .oxfmtrc.jsonc ignorePatterns
       {
         ...pluginOxfmt.configs.recommended,
         files: ['**/*.{js,ts}'],
+        rules: {
+          'oxfmt/oxfmt': ['error', { useConfig: false }],
+        },
       },
     ],
   })
@@ -285,3 +289,70 @@ configLoadingFixtures.forEach(
     })
   },
 )
+
+it('should match config-derived overrides relative to config directory, not ESLint cwd', async () => {
+  // ESLint cwd is the parent "nested-config/" directory, but the
+  // .oxfmtrc.json lives in "packages/a/". The config's overrides use
+  // files: ["src/**/*.ts"] which must be resolved relative to the config
+  // directory (packages/a/), not ESLint cwd (nested-config/).
+  const parentCwd = resolve('tests/fixtures/config-loading/nested-config')
+  const files = (
+    await glob('packages/a/src/**/*.{js,ts}', {
+      cwd: parentCwd,
+      onlyFiles: true,
+    })
+  ).sort()
+
+  const eslint = createEslint(parentCwd)
+  const results = await lintFixtureFiles(eslint, parentCwd, files)
+  const resultsByPath = mapResultsByFilePath(results)
+
+  // example.ts should be affected by the override (printWidth: 40)
+  const tsResult = resultsByPath.get(
+    resolve(parentCwd, 'packages/a/src/example.ts'),
+  )
+  expect(tsResult).toBeDefined()
+  expect(normalizeLintMessagesForSnapshot(tsResult!.messages)).toMatchSnapshot(
+    'packages/a/src/example.ts',
+  )
+
+  // normal.js should NOT be affected by the override (*.ts only)
+  const jsResult = resultsByPath.get(
+    resolve(parentCwd, 'packages/a/src/normal.js'),
+  )
+  expect(jsResult).toBeDefined()
+  expect(normalizeLintMessagesForSnapshot(jsResult!.messages)).toMatchSnapshot(
+    'packages/a/src/normal.js',
+  )
+})
+
+it('should match config-derived ignorePatterns relative to config directory, not ESLint cwd', async () => {
+  // Same nested-config fixture: .oxfmtrc.json in packages/a/ has
+  // ignorePatterns: ["**/ignored/**"]. Files under packages/a/ignored/
+  // should be ignored even when ESLint cwd is the parent directory.
+  const parentCwd = resolve('tests/fixtures/config-loading/nested-config')
+  const files = (
+    await glob('packages/a/**/*.{js,ts}', {
+      cwd: parentCwd,
+      onlyFiles: true,
+    })
+  ).sort()
+
+  const eslint = createEslint(parentCwd)
+  const results = await lintFixtureFiles(eslint, parentCwd, files)
+  const resultsByPath = mapResultsByFilePath(results)
+
+  // ignored/skipped.ts should produce no lint messages (ignored by config)
+  const ignoredResult = resultsByPath.get(
+    resolve(parentCwd, 'packages/a/ignored/skipped.ts'),
+  )
+  expect(ignoredResult).toBeDefined()
+  expect(ignoredResult!.messages).toHaveLength(0)
+
+  // src/example.ts should still produce lint messages (not ignored)
+  const srcResult = resultsByPath.get(
+    resolve(parentCwd, 'packages/a/src/example.ts'),
+  )
+  expect(srcResult).toBeDefined()
+  expect(srcResult!.messages.length).toBeGreaterThan(0)
+})

--- a/tests/eslint-plugin.test.ts
+++ b/tests/eslint-plugin.test.ts
@@ -263,6 +263,10 @@ const configLoadingFixtures = [
       'should apply .editorconfig sections and keep oxfmt overrides higher priority',
   },
   {
+    cwd: resolve('tests/fixtures/config-loading/nearest-editorconfig'),
+    title: 'should resolve nearest .editorconfig per file path',
+  },
+  {
     cwd: resolve('tests/fixtures/config-loading/config-priority'),
     title:
       'should prefer .oxfmtrc.json over .oxfmtrc.jsonc and oxfmt.config.ts',

--- a/tests/fixtures/config-loading/nearest-editorconfig/.editorconfig
+++ b/tests/fixtures/config-loading/nearest-editorconfig/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+insert_final_newline = false
+max_line_length = 40

--- a/tests/fixtures/config-loading/nearest-editorconfig/.oxfmtrc.json
+++ b/tests/fixtures/config-loading/nearest-editorconfig/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/tests/fixtures/config-loading/nearest-editorconfig/src/nested/.editorconfig
+++ b/tests/fixtures/config-loading/nearest-editorconfig/src/nested/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 6
+insert_final_newline = false
+max_line_length = 18

--- a/tests/fixtures/config-loading/nearest-editorconfig/src/nested/child.js
+++ b/tests/fixtures/config-loading/nearest-editorconfig/src/nested/child.js
@@ -1,0 +1,3 @@
+export function buildNestedUser(name) {
+    return createUserProfile(name, "a very long display name");
+}

--- a/tests/fixtures/config-loading/nearest-editorconfig/src/root.js
+++ b/tests/fixtures/config-loading/nearest-editorconfig/src/root.js
@@ -1,0 +1,3 @@
+export function buildRootUser(name) {
+    return createUserProfile(name, "a very long display name");
+}

--- a/tests/fixtures/config-loading/nested-config/packages/a/.oxfmtrc.json
+++ b/tests/fixtures/config-loading/nested-config/packages/a/.oxfmtrc.json
@@ -1,0 +1,12 @@
+{
+  "singleQuote": true,
+  "ignorePatterns": ["**/ignored/**"],
+  "overrides": [
+    {
+      "files": ["src/**/*.ts"],
+      "options": {
+        "printWidth": 40
+      }
+    }
+  ]
+}

--- a/tests/fixtures/config-loading/nested-config/packages/a/ignored/skipped.ts
+++ b/tests/fixtures/config-loading/nested-config/packages/a/ignored/skipped.ts
@@ -1,0 +1,1 @@
+export const unformatted =    "this should be ignored"

--- a/tests/fixtures/config-loading/nested-config/packages/a/src/example.ts
+++ b/tests/fixtures/config-loading/nested-config/packages/a/src/example.ts
@@ -1,0 +1,3 @@
+export function buildUser(name: string) {
+    return createUserProfile(name, "a very long display name");
+}

--- a/tests/fixtures/config-loading/nested-config/packages/a/src/normal.js
+++ b/tests/fixtures/config-loading/nested-config/packages/a/src/normal.js
@@ -1,0 +1,3 @@
+export function greet() {
+    console.log("hello world");
+}

--- a/workers/oxfmt.mjs
+++ b/workers/oxfmt.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { dirname, isAbsolute, join, relative } from 'node:path'
-import { loadOxfmtConfig } from 'load-oxfmt-config'
+import { loadOxfmtConfig, resolveOxfmtrcPath } from 'load-oxfmt-config'
 import { format } from 'oxfmt'
 import picomatch from 'picomatch'
 import { runAsWorker } from 'synckit'
@@ -23,6 +23,7 @@ import { runAsWorker } from 'synckit'
 /**
  * @typedef {object} ResolvedBaseOptions
  * @property {import('oxfmt').FormatConfig} baseOptions Resolved base formatter options.
+ * @property {string} configDir Directory of the resolved config file, used as base for config-derived glob patterns.
  */
 
 const MAX_CACHE_SIZE = 1000
@@ -170,11 +171,12 @@ function getConfigPathForFile(
 
 /**
  * Build cache key for merged options per file invocation.
- * The key includes filename, cwd, resolved base options, and rule-level
+ * The key includes filename, cwd, configDir, resolved base options, and rule-level
  * override inputs to avoid stale cache hits.
  *
  * @param filename - Current file path.
- * @param cwd - Base directory used for glob matching.
+ * @param cwd - Base directory used for rule-level glob matching.
+ * @param configDir - Directory of the resolved config file, used for config-derived glob matching.
  * @param baseOptions - Resolved base options used for formatting.
  * @param ignorePatterns - Rule-level ignore patterns.
  * @param overrides - Rule-level override entries.
@@ -186,6 +188,8 @@ function getMergedOptionsCacheKey(
   filename,
   /** @type {string} */
   cwd,
+  /** @type {string} */
+  configDir,
   /** @type {import('oxfmt').FormatConfig} */
   baseOptions,
   /** @type {string[] | undefined} */
@@ -198,6 +202,7 @@ function getMergedOptionsCacheKey(
   return JSON.stringify(
     {
       baseOptions,
+      configDir,
       cwd,
       filename,
       ignorePatterns,
@@ -283,6 +288,7 @@ async function resolveBaseOptions(
 
     if (!useConfig) {
       return {
+        configDir: cwd,
         baseOptions: {
           ...formatOptions,
         },
@@ -290,12 +296,18 @@ async function resolveBaseOptions(
     }
 
     const resolvedConfigPath = getConfigPathForFile(cwd, configPath)
+    const resolvedPath = await resolveOxfmtrcPath(
+      resolveFromDir,
+      resolvedConfigPath,
+    )
+    const configDir = resolvedPath ? dirname(resolvedPath) : cwd
     const configOptions = await loadOxfmtConfig({
       configPath: resolvedConfigPath,
       cwd: resolveFromDir,
     })
 
     return {
+      configDir,
       baseOptions: {
         ...configOptions,
         ...formatOptions,
@@ -364,7 +376,7 @@ runAsWorker(
       ...formatOptions
     } = options
 
-    const { baseOptions } = await resolveBaseOptions(
+    const { baseOptions, configDir } = await resolveBaseOptions(
       filename,
       cwd,
       configPath,
@@ -375,6 +387,7 @@ runAsWorker(
     const mergedOptionsCacheKey = getMergedOptionsCacheKey(
       filename,
       cwd,
+      configDir,
       baseOptions,
       ignorePatterns,
       overrides,
@@ -385,8 +398,9 @@ runAsWorker(
       baseOptions.ignorePatterns
     )
     const effectiveIgnorePatterns = ignorePatterns ?? baseIgnorePatterns
+    const ignoreBase = ignorePatterns == null ? configDir : cwd
 
-    if (shouldIgnoreFile(filename, cwd, effectiveIgnorePatterns)) {
+    if (shouldIgnoreFile(filename, ignoreBase, effectiveIgnorePatterns)) {
       return { code: sourceText }
     }
 
@@ -399,18 +413,21 @@ runAsWorker(
       baseOptions.overrides
     )
 
-    // Merge config-level and rule-level overrides (rule-level takes precedence)
-    const effectiveOverrides = useConfig
-      ? [...(baseOverrides ?? []), ...(overrides ?? [])]
-      : overrides
+    // Apply config-level overrides (relative to config directory)
+    let mergedOptions = baseOptions
+    if (useConfig && baseOverrides && baseOverrides.length > 0) {
+      mergedOptions = applyOverrides(
+        filename,
+        configDir,
+        mergedOptions,
+        baseOverrides,
+      )
+    }
 
-    // Apply overrides based on filename
-    const mergedOptions = applyOverrides(
-      filename,
-      cwd,
-      baseOptions,
-      effectiveOverrides,
-    )
+    // Apply rule-level overrides (relative to ESLint cwd)
+    if (overrides && overrides.length > 0) {
+      mergedOptions = applyOverrides(filename, cwd, mergedOptions, overrides)
+    }
 
     mergedOptionsCache.set(mergedOptionsCacheKey, mergedOptions)
     evictCache(mergedOptionsCache)

--- a/workers/oxfmt.mjs
+++ b/workers/oxfmt.mjs
@@ -25,11 +25,56 @@ import { runAsWorker } from 'synckit'
  * @property {import('oxfmt').FormatConfig} baseOptions Resolved base formatter options.
  */
 
+const MAX_CACHE_SIZE = 1000
+
+/**
+ * Evict oldest entries when the cache exceeds MAX_CACHE_SIZE.
+ * @param cache - The cache map to evict entries from
+ */
+function evictCache(
+  /** @type {Map<string, unknown>} */
+  cache,
+) {
+  if (cache.size <= MAX_CACHE_SIZE) {
+    return
+  }
+  const keysToDelete = [...cache.keys()].slice(0, cache.size - MAX_CACHE_SIZE)
+  for (const key of keysToDelete) {
+    cache.delete(key)
+  }
+}
+
+/**
+ * JSON.stringify replacer that sorts object keys for stable serialization.
+ * @param key - The key of the property being processed
+ * @param value - The value of the property being processed
+ * @returns - The value to be serialized, with object keys sorted if it's an object
+ */
+function stableReplacer(
+  /** @type {string} */
+  key,
+  /** @type {unknown} */
+  value,
+) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return Object.keys(value)
+      .sort()
+      .reduce((sorted, k) => {
+        sorted[k] = /** @type {Record<string, unknown>} */ (value)[k]
+        return sorted
+      }, /** @type {Record<string, unknown>} */ ({}))
+  }
+  return value
+}
+
 /** @type {Map<string, Promise<ResolvedBaseOptions>>} */
 const resolvedBaseOptionsCache = new Map()
 
 /** @type {Map<string, import('oxfmt').FormatConfig>} */
 const mergedOptionsCache = new Map()
+
+/** @type {Map<string, ReturnType<typeof picomatch>>} */
+const picomatchCache = new Map()
 
 /**
  * Apply overrides to the base options based on the filename
@@ -64,12 +109,12 @@ function applyOverrides(
     const { excludeFiles, files, options: overrideOptions } = override
 
     // Check if file matches the files patterns
-    const matches = picomatch.isMatch(relativePath, files)
+    const matches = getCachedMatcher(files)(relativePath)
 
     // Check if file is excluded
     const excluded =
       excludeFiles && excludeFiles.length > 0
-        ? picomatch.isMatch(relativePath, excludeFiles)
+        ? getCachedMatcher(excludeFiles)(relativePath)
         : false
 
     if (matches && !excluded && overrideOptions) {
@@ -79,6 +124,26 @@ function applyOverrides(
   }
 
   return hasOverrides ? mergedOptions : baseOptions
+}
+
+/**
+ * Get or create a cached picomatch matcher for the given patterns.
+ * @param patterns - Glob patterns to match against file paths
+ * @returns - Picomatch matcher function
+ */
+function getCachedMatcher(
+  /** @type {string | string[]} */
+  patterns,
+) {
+  const key = Array.isArray(patterns) ? patterns.join('\0') : patterns
+  const cached = picomatchCache.get(key)
+  if (cached) {
+    return cached
+  }
+  const matcher = picomatch(patterns)
+  picomatchCache.set(key, matcher)
+  evictCache(picomatchCache)
+  return matcher
 }
 
 /**
@@ -110,7 +175,7 @@ function getConfigPathForFile(
  *
  * @param filename - Current file path.
  * @param cwd - Base directory used for glob matching.
- * @param formatOptions - Base options used for formatting.
+ * @param baseOptions - Resolved base options used for formatting.
  * @param ignorePatterns - Rule-level ignore patterns.
  * @param overrides - Rule-level override entries.
  * @param useConfig - Whether config file loading is enabled.
@@ -122,7 +187,7 @@ function getMergedOptionsCacheKey(
   /** @type {string} */
   cwd,
   /** @type {import('oxfmt').FormatConfig} */
-  formatOptions,
+  baseOptions,
   /** @type {string[] | undefined} */
   ignorePatterns,
   /** @type {Override[] | undefined} */
@@ -130,14 +195,17 @@ function getMergedOptionsCacheKey(
   /** @type {boolean} */
   useConfig,
 ) {
-  return JSON.stringify({
-    cwd,
-    filename,
-    formatOptions,
-    ignorePatterns,
-    overrides,
-    useConfig,
-  })
+  return JSON.stringify(
+    {
+      baseOptions,
+      cwd,
+      filename,
+      ignorePatterns,
+      overrides,
+      useConfig,
+    },
+    stableReplacer,
+  )
 }
 
 /**
@@ -163,13 +231,16 @@ function getResolvedBaseOptionsCacheKey(
   /** @type {import('oxfmt').FormatConfig} */
   formatOptions,
 ) {
-  return JSON.stringify({
-    configPath: configPath || '',
-    cwd,
-    fileDir: dirname(filename),
-    formatOptions,
-    useConfig,
-  })
+  return JSON.stringify(
+    {
+      configPath: configPath || '',
+      cwd,
+      fileDir: dirname(filename),
+      formatOptions,
+      useConfig,
+    },
+    stableReplacer,
+  )
 }
 
 /**
@@ -233,6 +304,7 @@ async function resolveBaseOptions(
   })()
 
   resolvedBaseOptionsCache.set(cacheKey, task)
+  evictCache(resolvedBaseOptionsCache)
 
   try {
     return await task
@@ -265,7 +337,7 @@ function shouldIgnoreFile(
   const relativePath = relative(cwd, filename).replace(/\\/g, '/')
 
   // Check if file matches any ignore pattern
-  return picomatch.isMatch(relativePath, ignorePatterns)
+  return getCachedMatcher(ignorePatterns)(relativePath)
 }
 
 runAsWorker(
@@ -309,43 +381,40 @@ runAsWorker(
       useConfig,
     )
 
-    const cachedMergedOptions = mergedOptionsCache.get(mergedOptionsCacheKey)
-    if (cachedMergedOptions) {
-      const cachedIgnorePatterns = /** @type {string[] | undefined} */ (
-        cachedMergedOptions.ignorePatterns
-      )
-
-      if (
-        shouldIgnoreFile(filename, cwd, ignorePatterns || cachedIgnorePatterns)
-      ) {
-        return { code: sourceText }
-      }
-
-      return format(filename, sourceText, cachedMergedOptions)
-    }
-
     const baseIgnorePatterns = /** @type {string[] | undefined} */ (
       baseOptions.ignorePatterns
     )
+    const effectiveIgnorePatterns = ignorePatterns ?? baseIgnorePatterns
+
+    if (shouldIgnoreFile(filename, cwd, effectiveIgnorePatterns)) {
+      return { code: sourceText }
+    }
+
+    const cachedMergedOptions = mergedOptionsCache.get(mergedOptionsCacheKey)
+    if (cachedMergedOptions) {
+      return format(filename, sourceText, cachedMergedOptions)
+    }
+
     const baseOverrides = /** @type {Override[] | undefined} */ (
       baseOptions.overrides
     )
 
-    if (shouldIgnoreFile(filename, cwd, ignorePatterns || baseIgnorePatterns)) {
-      return { code: sourceText }
-    }
+    // Merge config-level and rule-level overrides (rule-level takes precedence)
+    const effectiveOverrides = useConfig
+      ? [...(baseOverrides ?? []), ...(overrides ?? [])]
+      : overrides
 
     // Apply overrides based on filename
     const mergedOptions = applyOverrides(
       filename,
       cwd,
       baseOptions,
-      useConfig ? baseOverrides : overrides,
+      effectiveOverrides,
     )
 
     mergedOptionsCache.set(mergedOptionsCacheKey, mergedOptions)
+    evictCache(mergedOptionsCache)
 
-    const formatResult = await format(filename, sourceText, mergedOptions)
-    return formatResult
+    return format(filename, sourceText, mergedOptions)
   },
 )

--- a/workers/oxfmt.mjs
+++ b/workers/oxfmt.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { relative } from 'node:path'
+import { dirname, isAbsolute, join, relative } from 'node:path'
 import { loadOxfmtConfig } from 'load-oxfmt-config'
 import { format } from 'oxfmt'
 import picomatch from 'picomatch'
@@ -12,6 +12,7 @@ import { runAsWorker } from 'synckit'
  * @property {string} cwd - Current working directory for resolving configuration
  * @property {string} [configPath] - Custom path to oxfmt configuration file
  */
+
 /**
  * @typedef {import('load-oxfmt-config').OxfmtConfigOverride} Override
  */
@@ -20,9 +21,20 @@ import { runAsWorker } from 'synckit'
  */
 
 /**
+ * @typedef {object} ResolvedBaseOptions
+ * @property {import('oxfmt').FormatConfig} baseOptions Resolved base formatter options.
+ */
+
+/** @type {Map<string, Promise<ResolvedBaseOptions>>} */
+const resolvedBaseOptionsCache = new Map()
+
+/** @type {Map<string, import('oxfmt').FormatConfig>} */
+const mergedOptionsCache = new Map()
+
+/**
  * Apply overrides to the base options based on the filename
  * @param filename - The file path
- * @param cwd - Current working directory
+ * @param cwd - Base directory for glob matching
  * @param baseOptions - Base format options
  * @param [overrides] - Override configurations
  * @returns - Merged options
@@ -70,9 +82,170 @@ function applyOverrides(
 }
 
 /**
+ * Resolve an effective config path for a file.
+ * - Absolute paths are returned as-is.
+ * - Relative paths are resolved from cwd.
+ *
+ * @param cwd - Current working directory from ESLint context.
+ * @param [configPath] - Optional user-provided config path.
+ * @returns Absolute config path when provided, otherwise undefined.
+ */
+function getConfigPathForFile(
+  /** @type {string} */
+  cwd,
+  /** @type {string | undefined} */
+  configPath,
+) {
+  if (!configPath) {
+    return undefined
+  }
+
+  return isAbsolute(configPath) ? configPath : join(cwd, configPath)
+}
+
+/**
+ * Build cache key for merged options per file invocation.
+ * The key includes filename, cwd, resolved base options, and rule-level
+ * override inputs to avoid stale cache hits.
+ *
+ * @param filename - Current file path.
+ * @param cwd - Base directory used for glob matching.
+ * @param formatOptions - Base options used for formatting.
+ * @param ignorePatterns - Rule-level ignore patterns.
+ * @param overrides - Rule-level override entries.
+ * @param useConfig - Whether config file loading is enabled.
+ * @returns Serialized cache key.
+ */
+function getMergedOptionsCacheKey(
+  /** @type {string} */
+  filename,
+  /** @type {string} */
+  cwd,
+  /** @type {import('oxfmt').FormatConfig} */
+  formatOptions,
+  /** @type {string[] | undefined} */
+  ignorePatterns,
+  /** @type {Override[] | undefined} */
+  overrides,
+  /** @type {boolean} */
+  useConfig,
+) {
+  return JSON.stringify({
+    cwd,
+    filename,
+    formatOptions,
+    ignorePatterns,
+    overrides,
+    useConfig,
+  })
+}
+
+/**
+ * Build cache key for resolving base formatter options.
+ * The key includes file directory and all resolution inputs.
+ *
+ * @param filename - Current file path.
+ * @param cwd - Current working directory from ESLint context.
+ * @param configPath - Optional user-provided config path.
+ * @param useConfig - Whether config file loading is enabled.
+ * @param formatOptions - Rule-level format options.
+ * @returns Serialized cache key.
+ */
+function getResolvedBaseOptionsCacheKey(
+  /** @type {string} */
+  filename,
+  /** @type {string} */
+  cwd,
+  /** @type {string | undefined} */
+  configPath,
+  /** @type {boolean} */
+  useConfig,
+  /** @type {import('oxfmt').FormatConfig} */
+  formatOptions,
+) {
+  return JSON.stringify({
+    configPath: configPath || '',
+    cwd,
+    fileDir: dirname(filename),
+    formatOptions,
+    useConfig,
+  })
+}
+
+/**
+ * Resolve base formatter options for a file and cache the async result.
+ *
+ * @param filename - Current file path.
+ * @param cwd - Current working directory from ESLint context.
+ * @param configPath - Optional user-provided config path.
+ * @param useConfig - Whether config file loading is enabled.
+ * @param formatOptions - Rule-level format options.
+ * @returns Base options after config loading and inline option merge.
+ */
+async function resolveBaseOptions(
+  /** @type {string} */
+  filename,
+  /** @type {string} */
+  cwd,
+  /** @type {string | undefined} */
+  configPath,
+  /** @type {boolean} */
+  useConfig,
+  /** @type {import('oxfmt').FormatConfig} */
+  formatOptions,
+) {
+  const cacheKey = getResolvedBaseOptionsCacheKey(
+    filename,
+    cwd,
+    configPath,
+    useConfig,
+    formatOptions,
+  )
+
+  const cachedTask = resolvedBaseOptionsCache.get(cacheKey)
+  if (cachedTask) {
+    return cachedTask
+  }
+
+  const task = (async () => {
+    const resolveFromDir = dirname(filename)
+
+    if (!useConfig) {
+      return {
+        baseOptions: {
+          ...formatOptions,
+        },
+      }
+    }
+
+    const resolvedConfigPath = getConfigPathForFile(cwd, configPath)
+    const configOptions = await loadOxfmtConfig({
+      configPath: resolvedConfigPath,
+      cwd: resolveFromDir,
+    })
+
+    return {
+      baseOptions: {
+        ...configOptions,
+        ...formatOptions,
+      },
+    }
+  })()
+
+  resolvedBaseOptionsCache.set(cacheKey, task)
+
+  try {
+    return await task
+  } catch (err) {
+    resolvedBaseOptionsCache.delete(cacheKey)
+    throw err
+  }
+}
+
+/**
  * Check if a file should be ignored based on ignorePatterns
  * @param filename - The file path
- * @param cwd - Current working directory
+ * @param cwd - Base directory for glob matching
  * @param [ignorePatterns] - Ignore patterns
  * @returns - Whether the file should be ignored
  */
@@ -119,24 +292,46 @@ runAsWorker(
       ...formatOptions
     } = options
 
-    // Load base options from config or use provided options
-    const baseOptions = {
-      ...(useConfig
-        ? await loadOxfmtConfig({
-            configPath,
-            cwd,
-          })
-        : {}),
-      ...formatOptions,
+    const { baseOptions } = await resolveBaseOptions(
+      filename,
+      cwd,
+      configPath,
+      useConfig,
+      formatOptions,
+    )
+
+    const mergedOptionsCacheKey = getMergedOptionsCacheKey(
+      filename,
+      cwd,
+      baseOptions,
+      ignorePatterns,
+      overrides,
+      useConfig,
+    )
+
+    const cachedMergedOptions = mergedOptionsCache.get(mergedOptionsCacheKey)
+    if (cachedMergedOptions) {
+      const cachedIgnorePatterns = /** @type {string[] | undefined} */ (
+        cachedMergedOptions.ignorePatterns
+      )
+
+      if (
+        shouldIgnoreFile(filename, cwd, ignorePatterns || cachedIgnorePatterns)
+      ) {
+        return { code: sourceText }
+      }
+
+      return format(filename, sourceText, cachedMergedOptions)
     }
 
-    if (
-      shouldIgnoreFile(
-        filename,
-        cwd,
-        ignorePatterns || baseOptions.ignorePatterns,
-      )
-    ) {
+    const baseIgnorePatterns = /** @type {string[] | undefined} */ (
+      baseOptions.ignorePatterns
+    )
+    const baseOverrides = /** @type {Override[] | undefined} */ (
+      baseOptions.overrides
+    )
+
+    if (shouldIgnoreFile(filename, cwd, ignorePatterns || baseIgnorePatterns)) {
       return { code: sourceText }
     }
 
@@ -145,8 +340,10 @@ runAsWorker(
       filename,
       cwd,
       baseOptions,
-      useConfig ? baseOptions.overrides : overrides,
+      useConfig ? baseOverrides : overrides,
     )
+
+    mergedOptionsCache.set(mergedOptionsCacheKey, mergedOptions)
 
     const formatResult = await format(filename, sourceText, mergedOptions)
     return formatResult


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added fixtures and targeted tests to validate nearest-editorconfig resolution and correct handling of config-derived overrides and ignore patterns.

* **Performance**
  * Improved formatter worker with layered in-memory caching and cached matchers for faster, more consistent formatting.

* **Bug Fixes**
  * Config resolution, override application, and ignore-pattern matching now resolve relative to the configuration location (not the process cwd).

* **Documentation**
  * Updated developer workflow and config-loading documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->