### PR TITLE
fix: cache oxfmt config resolution per directory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1106,8 +1106,8 @@ packages:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
 
-  caniuse-lite@1.0.30001787:
-    resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
+  caniuse-lite@1.0.30001788:
+    resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -3439,7 +3439,7 @@ snapshots:
   browserslist@4.28.2:
     dependencies:
       baseline-browser-mapping: 2.10.18
-      caniuse-lite: 1.0.30001787
+      caniuse-lite: 1.0.30001788
       electron-to-chromium: 1.5.336
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
@@ -3460,7 +3460,7 @@ snapshots:
 
   cac@7.0.0: {}
 
-  caniuse-lite@1.0.30001787: {}
+  caniuse-lite@1.0.30001788: {}
 
   ccount@2.0.1: {}
 

--- a/tests/__snapshots__/eslint-plugin.test.ts.snap
+++ b/tests/__snapshots__/eslint-plugin.test.ts.snap
@@ -179,6 +179,19 @@ exports[`should apply .editorconfig sections and keep oxfmt overrides higher pri
 }
 `;
 
+exports[`should apply .editorconfig settings when no oxfmt config exists 1`] = `
+{
+  "fixture": "editorconfig-only",
+  "summary": [
+    {
+      "file": "src/example.js",
+      "messages": [],
+      "output": null,
+    },
+  ],
+}
+`;
+
 exports[`should lint work > ts.ts 1`] = `
 [
   {

--- a/tests/eslint-plugin.test.ts
+++ b/tests/eslint-plugin.test.ts
@@ -281,6 +281,10 @@ const CONFIG_LOADER_FIXTURES = [
     title:
       'should prefer .oxfmtrc.json over .oxfmtrc.jsonc and oxfmt.config.ts',
   },
+  {
+    cwd: resolve('tests/fixtures/config-loading/editorconfig-only'),
+    title: 'should apply .editorconfig settings when no oxfmt config exists',
+  },
 ] as const
 
 CONFIG_LOADER_FIXTURES.forEach(

--- a/tests/fixtures/config-loading/editorconfig-only/.editorconfig
+++ b/tests/fixtures/config-loading/editorconfig-only/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+insert_final_newline = false
+max_line_length = 40

--- a/tests/fixtures/config-loading/editorconfig-only/src/example.js
+++ b/tests/fixtures/config-loading/editorconfig-only/src/example.js
@@ -1,0 +1,3 @@
+export function buildUser(name) {
+    return createUserProfile(name, "a very long display name");
+}

--- a/workers/oxfmt.mjs
+++ b/workers/oxfmt.mjs
@@ -7,13 +7,6 @@ import picomatch from 'picomatch'
 import { runAsWorker } from 'synckit'
 
 /**
- * @typedef {object} PluginOptions
- * @property {boolean} [useConfig] - Whether to use oxfmt configuration file
- * @property {string} cwd - Current working directory for resolving configuration
- * @property {string} [configPath] - Custom path to oxfmt configuration file
- */
-
-/**
  * @typedef {import('load-oxfmt-config').OxfmtConfigOverride} Override
  */
 /**
@@ -21,9 +14,22 @@ import { runAsWorker } from 'synckit'
  */
 
 /**
+ * @typedef {object} PluginOptions
+ * @property {boolean} [useConfig] - Whether to use oxfmt configuration file
+ * @property {string} cwd - Current working directory for resolving configuration
+ * @property {string} [configPath] - Custom path to oxfmt configuration file
+ */
+
+/**
  * @typedef {object} ResolvedBaseOptions
  * @property {import('oxfmt').FormatConfig} baseOptions Resolved base formatter options.
  * @property {string} configDir Directory of the resolved config file, used as base for config-derived glob patterns.
+ */
+
+/**
+ * @typedef {object} ResolvedOxfmtConfig
+ * @property {string} configDir Directory of the resolved config file.
+ * @property {string | undefined} resolvedConfigPath Absolute path to the config file, or undefined.
  */
 
 const MAX_CACHE_SIZE = 1000
@@ -76,6 +82,9 @@ const mergedOptionsCache = new Map()
 
 /** @type {Map<string, ReturnType<typeof picomatch>>} */
 const picomatchCache = new Map()
+
+/** @type {Map<string, Promise<ResolvedOxfmtConfig>>} */
+const oxfmtConfigResolutionCache = new Map()
 
 /**
  * Apply overrides to the base options based on the filename
@@ -251,6 +260,10 @@ function getResolvedBaseOptionsCacheKey(
 /**
  * Resolve base formatter options for a file and cache the async result.
  *
+ * The oxfmt configuration file is resolved once per `cwd + configPath` pair
+ * (via `resolveOxfmtConfigOnce`), while `.editorconfig` is still resolved
+ * per file directory to support nearest-editorconfig scenarios.
+ *
  * @param filename - Current file path.
  * @param cwd - Current working directory from ESLint context.
  * @param configPath - Optional user-provided config path.
@@ -285,8 +298,6 @@ async function resolveBaseOptions(
 
   /** @type {Promise<ResolvedBaseOptions>} */
   const task = (async () => {
-    const resolveFromDir = dirname(filename)
-
     if (!useConfig) {
       return {
         configDir: cwd,
@@ -296,15 +307,21 @@ async function resolveBaseOptions(
       }
     }
 
-    const resolvedConfigPath = getConfigPathForFile(cwd, configPath)
-    const resolvedPath = await resolveOxfmtrcPath(
-      resolveFromDir,
-      resolvedConfigPath,
+    // Resolve oxfmt config path once per file directory + configPath pair.
+    // Walks upward from the file's directory, but caches the result so files
+    // in the same (or child) directories reuse the resolved path.
+    const { configDir, resolvedConfigPath } = await resolveOxfmtConfigOnce(
+      dirname(filename),
+      configPath,
     )
-    const configDir = resolvedPath ? dirname(resolvedPath) : cwd
+
+    // Load config: use pre-resolved config path to skip the redundant oxfmt
+    // config walk inside loadOxfmtConfig, but still resolve .editorconfig
+    // per file directory via editorconfig.cwd
     const configOptions = await loadOxfmtConfig({
       configPath: resolvedConfigPath,
-      cwd: resolveFromDir,
+      cwd,
+      editorconfig: { cwd: dirname(filename) },
     })
 
     return {
@@ -323,6 +340,47 @@ async function resolveBaseOptions(
     return await task
   } catch (err) {
     resolvedBaseOptionsCache.delete(cacheKey)
+    throw err
+  }
+}
+
+/**
+ * Resolve the oxfmt config file path once per `cwd + configPath` pair and cache
+ * the result. When no explicit configPath is given, discovers the config by
+ * walking upward from `cwd`.
+ *
+ * @param cwd - Directory to start searching from.
+ * @param [configPath] - Optional user-provided config path.
+ * @returns Resolved config directory and absolute config path.
+ */
+async function resolveOxfmtConfigOnce(
+  /** @type {string} */
+  cwd,
+  /** @type {string | undefined} */
+  configPath,
+) {
+  const key = `${cwd}::${configPath || ''}`
+  const cached = oxfmtConfigResolutionCache.get(key)
+  if (cached) {
+    return cached
+  }
+
+  const task = (async () => {
+    const resolvedConfigPath = getConfigPathForFile(cwd, configPath)
+    const resolvedPath = await resolveOxfmtrcPath(cwd, resolvedConfigPath)
+    return {
+      configDir: resolvedPath ? dirname(resolvedPath) : cwd,
+      resolvedConfigPath: resolvedPath,
+    }
+  })()
+
+  oxfmtConfigResolutionCache.set(key, task)
+  evictCache(oxfmtConfigResolutionCache)
+
+  try {
+    return await task
+  } catch (err) {
+    oxfmtConfigResolutionCache.delete(key)
     throw err
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full .editorconfig support: the plugin now respects .editorconfig settings when no oxfmt configuration is present

* **Improvements**
  * Faster, more reliable configuration resolution via a new caching mechanism

* **Tests**
  * Added a test verifying .editorconfig behavior when no oxfmt config exists
<!-- end of auto-generated comment: release notes by coderabbit.ai -->